### PR TITLE
fix: add empty label for "to" field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       "devDependencies": {
         "@types/jest": "^29.4.0",
         "@types/node": "^18.13.0",
-        "h5p-types": "^1.6.1",
+        "h5p-types": "^1.7.0",
         "jest": "^29.4.2",
-        "prettier": "^2.8.3",
+        "prettier": "^2.8.4",
         "prettier-config": "github:boyum/prettier-config",
         "sass": "^1.58.0",
         "ts-jest": "^29.0.5",
@@ -2587,9 +2587,9 @@
       "dev": true
     },
     "node_modules/h5p-types": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/h5p-types/-/h5p-types-1.6.1.tgz",
-      "integrity": "sha512-odcuuMAwTeJEtQuDonO1kHfyKXPT44LfJn71EnleNONAP070OAbkq3iCa2QASIGEl/3asfcfYU+hPnPxZGzHmg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/h5p-types/-/h5p-types-1.7.0.tgz",
+      "integrity": "sha512-v5RxPN0ukAlqO3FgzddLCRtezT4FmwFDnNKrpsz9YQsT//wLpSvS6ICztgEJyeNadt5aLoTnNf0HQU/h32fQRw==",
       "dev": true,
       "dependencies": {
         "@types/jquery": "^3.5.16"
@@ -3890,9 +3890,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "devDependencies": {
     "@types/jest": "^29.4.0",
     "@types/node": "^18.13.0",
-    "h5p-types": "^1.6.1",
+    "h5p-types": "^1.7.0",
     "jest": "^29.4.2",
-    "prettier": "^2.8.3",
+    "prettier": "^2.8.4",
     "prettier-config": "github:boyum/prettier-config",
     "sass": "^1.58.0",
     "ts-jest": "^29.0.5",

--- a/semantics.json
+++ b/semantics.json
@@ -92,7 +92,8 @@
               "min": 0,
               "max": 100,
               "default": 100,
-              "unit": "%"
+              "unit": "%",
+              "label": ""
             },
             {
               "name": "feedback",

--- a/semantics.json.d.ts
+++ b/semantics.json.d.ts
@@ -128,7 +128,8 @@ declare const $defaultExport: [
 							min: 0,
 							max: 100,
 							"default": 100,
-							unit: "%"
+							unit: "%",
+							label: ""
 						},
 						{
 							name: "feedback",


### PR DESCRIPTION
The `label` field is considered required and `InferParamsFromSemantics` treats is as such. To avoid it from appearing in the score range widget, we set it to empty.