### PR TITLE
fix: wait longer for retry button to be added to the DOM

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.VocabularyDrill",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 17,
+  "patchVersion": 18,
   "runnable": 1,
   "license": "MIT",
   "author": "NDLA",

--- a/library.json.d.ts
+++ b/library.json.d.ts
@@ -3,7 +3,7 @@ declare const json: {
   "machineName": "H5P.VocabularyDrill",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 17,
+  "patchVersion": 18,
   "runnable": 1,
   "license": "MIT",
   "author": "NDLA",

--- a/src/components/VocabularyDrill/VocabularyDrill.tsx
+++ b/src/components/VocabularyDrill/VocabularyDrill.tsx
@@ -299,8 +299,10 @@ export const VocabularyDrill: FC<VocabularyDrillProps> = ({
             // Wait for the retry button to be added to the DOM
             requestAnimationFrame(() => {
               requestAnimationFrame(() => {
-                const retryButton = wrapper.querySelector('button.h5p-question-try-again');
-                retryButton?.addEventListener('click', handleRetry, { once: true });
+                requestAnimationFrame(() => {
+                  const retryButton = wrapper.querySelector('button.h5p-question-try-again');
+                  retryButton?.addEventListener('click', handleRetry, { once: true });
+                });
               });
             });
           }

--- a/src/components/VocabularyDrill/VocabularyDrill.tsx
+++ b/src/components/VocabularyDrill/VocabularyDrill.tsx
@@ -299,6 +299,8 @@ export const VocabularyDrill: FC<VocabularyDrillProps> = ({
             // Wait for the retry button to be added to the DOM
             requestAnimationFrame(() => {
               requestAnimationFrame(() => {
+                // The retry button is not always added to the DOM at this point when DragText
+                // is used, so we need to wait for the next animation frame to be sure
                 requestAnimationFrame(() => {
                   const retryButton = wrapper.querySelector('button.h5p-question-try-again');
                   retryButton?.addEventListener('click', handleRetry, { once: true });


### PR DESCRIPTION
If a user clicks very fast on "Check" => "Retry" or "Check" => "Show solution" => "Retry", the click on the Retry button is not always captured. This is not the most common senario but we can perhaps delay one extra frame to ensure that the tool buttons will not be disabled after Retry is clicked.

This seems to only concern "DragText" and not "FillIn".