### PR TITLE
fix: only create uuid once

### DIFF
--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { H5P } from 'h5p-utils';
 
 type ComboboxOption = {
   index?: number;

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -3,6 +3,7 @@ import { H5P } from 'h5p-utils';
 
 type ComboboxOption = {
   index?: number;
+  key?: string;
   value: any;
   label: string;
   className: string;
@@ -206,11 +207,12 @@ export const Combobox: React.FC<ComboboxProps> = ({
         >
           {options.map((option, index) => {
             option.index = index;
+            option.key = option.key ?? H5P.createUUID();
             return (
               <div
                 role="option"
                 id={`${id}-option-${index}`}
-                key={H5P.createUUID()}
+                key={option.key}
                 className={`combo-option ${selectedOption.index === option.index ? 'option-current' : ''}`}
                 aria-selected={activeOption.index === option.index}
                 onClick={() => handleChangeOption(option)}

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -3,7 +3,6 @@ import { H5P } from 'h5p-utils';
 
 type ComboboxOption = {
   index?: number;
-  key?: string;
   value: any;
   label: string;
   className: string;
@@ -207,12 +206,12 @@ export const Combobox: React.FC<ComboboxProps> = ({
         >
           {options.map((option, index) => {
             option.index = index;
-            option.key = option.key ?? H5P.createUUID();
+
             return (
               <div
                 role="option"
                 id={`${id}-option-${index}`}
-                key={option.key}
+                key={option.value}
                 className={`combo-option ${selectedOption.index === option.index ? 'option-current' : ''}`}
                 aria-selected={activeOption.index === option.index}
                 onClick={() => handleChangeOption(option)}


### PR DESCRIPTION
VoiceOver had problems following the focused option after the options got their key attribute with uuid. When opening the Combobox the first element was read correctly, but when navigating to the next element the VoiceOver did not follow and was still on the first element. Seems to be ok after making sure the uuid is only created one time. 

<img width="285" alt="Skjermbilde 2023-04-26 kl  19 18 58" src="https://user-images.githubusercontent.com/35261194/234654389-73214d11-9a2a-40ce-a47b-26f9e050b43d.png">
