### PR TITLE
build: turn on `verbatimModuleSyntax`

### DIFF
--- a/.h5pignore
+++ b/.h5pignore
@@ -14,4 +14,5 @@ package.json
 README.md
 semantics.json.d.ts
 tsconfig.json
+tsconfig.jest.json
 webpack.config.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,13 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+  transform: {
+    '.ts': [
+      'ts-jest',
+      {
+        // Use separate tsconfig for tests as ts-node doesn't work well with `verbatimModuleSyntax` in cjs projects
+        // https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1515758013
+        tsconfig: './tsconfig.jest.json',
+      },
+    ],
+  },
 };

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import { H5P } from 'h5p-utils';
-import React, { FC, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, type FC } from 'react';
 
 type ProgressBarProps = {
   page: number;

--- a/src/components/ScoreBar/ScoreBar.tsx
+++ b/src/components/ScoreBar/ScoreBar.tsx
@@ -1,5 +1,5 @@
 import { H5P } from 'h5p-utils';
-import React, { FC, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, type FC } from 'react';
 import { useTranslation } from '../../hooks/useTranslation/useTranslation';
 
 type ScoreBarProps = {

--- a/src/components/ScorePage/ScorePage.tsx
+++ b/src/components/ScorePage/ScorePage.tsx
@@ -1,7 +1,7 @@
 import { H5P } from 'h5p-utils';
-import React, { FC } from 'react';
-import { ScoreBar } from '../ScoreBar/ScoreBar';
+import React, { type FC } from 'react';
 import { useTranslation } from '../../hooks/useTranslation/useTranslation';
+import { ScoreBar } from '../ScoreBar/ScoreBar';
 
 type ScorePageProps = {
   score: number;

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -1,6 +1,6 @@
-import React, { FC } from 'react';
-import { ProgressBar } from '../ProgressBar/ProgressBar';
+import React, { type FC } from 'react';
 import { useTranslation } from '../../hooks/useTranslation/useTranslation';
+import { ProgressBar } from '../ProgressBar/ProgressBar';
 
 type StatusBarProps = {
   page: number;

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import he from 'he';
-import { useTranslation } from '../../hooks/useTranslation/useTranslation';
-import { useAriaLive } from '../../hooks/useAriaLive/useAriaLive';
-import { AnswerModeType, LanguageCode, LanguageModeType } from '../../types/types';
-import { Combobox } from '../Combobox/Combobox';
 import { H5P } from 'h5p-utils';
+import { decode } from 'he';
+import React from 'react';
+import { useAriaLive } from '../../hooks/useAriaLive/useAriaLive';
+import { useTranslation } from '../../hooks/useTranslation/useTranslation';
+import { AnswerModeType, LanguageModeType, type LanguageCode } from '../../types/types';
 import { getLanguageModeAria } from '../../utils/language.utils';
+import { Combobox } from '../Combobox/Combobox';
 
 type ToolbarProps = {
   title: string;
@@ -55,7 +55,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
   return (
     <div className="h5p-vocabulary-drill-toolbar">
-      <p>{he.decode(title)}</p>
+      <p>{decode(title)}</p>
       {enableTools && (
         <div className="h5p-vocabulary-drill-toolbar-tools">
           {enableAnswerMode && (

--- a/src/components/VocabularyDrill/VocabularyDrill.tsx
+++ b/src/components/VocabularyDrill/VocabularyDrill.tsx
@@ -1,23 +1,23 @@
-import { H5PExtrasWithState, H5PLibrary, XAPIEvent, XAPIVerb } from 'h5p-types';
+import type { H5PExtrasWithState, H5PLibrary, XAPIEvent, XAPIVerb } from 'h5p-types';
 import { H5P } from 'h5p-utils';
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, type FC } from 'react';
 import { useContentId } from 'use-h5p';
+import { AriaLiveContext } from '../../contexts/AriaLiveContext';
 import { useTranslation } from '../../hooks/useTranslation/useTranslation';
 import {
   AnswerModeType,
-  SubContentType,
   LanguageModeType,
-  Params,
-  State,
+  type Params,
+  type State,
+  type SubContentType,
 } from '../../types/types';
 import { findLibraryInfo, libraryToString, sanitizeRecord } from '../../utils/h5p.utils';
 import { isNil } from '../../utils/type.utils';
-import { parseWords, pickWords, parseSourceAndTarget, pickRandomWords } from '../../utils/word.utils';
-import { StatusBar } from '../StatusBar/StatusBar';
-import { Toolbar } from '../Toolbar/Toolbar';
-import { AriaLiveContext } from '../../contexts/AriaLiveContext';
+import { parseSourceAndTarget, parseWords, pickRandomWords, pickWords } from '../../utils/word.utils';
 import { AriaLive } from '../AriaLive/AriaLive';
 import { ScorePage } from '../ScorePage/ScorePage';
+import { StatusBar } from '../StatusBar/StatusBar';
+import { Toolbar } from '../Toolbar/Toolbar';
 
 type VocabularyDrillProps = {
   title: string;

--- a/src/hooks/useTranslation/useTranslation.ts
+++ b/src/hooks/useTranslation/useTranslation.ts
@@ -1,5 +1,5 @@
 import { useTranslation as useH5PTranslation } from 'use-h5p';
-import { TranslationKey } from '../../types/types';
+import type { TranslationKey } from '../../types/types';
 
 export const useTranslation = () => {
   const { t } = useH5PTranslation();

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IH5PQuestionType,
   InferParamsFromSemantics,
   ReadonlyDeep,
@@ -32,10 +32,3 @@ export type State = {
 };
 
 export type SubContentType = IH5PQuestionType & H5PResumableContentType;
-
-// By using `semantics` we let `unplugin-json-dts` know that we want it to
-// generate `semantics.json.d.ts. This is a hack and should be avoided in
-// the future.
-// TODO: Remove this hack when `unplugin-json-dts` starts generating types
-// for JSON files that are imported in type scope.
-semantics;

--- a/src/utils/language.utils.ts
+++ b/src/utils/language.utils.ts
@@ -1,5 +1,5 @@
-import { LanguageCode, LanguageModeType } from '../types/types';
 import { useTranslation } from '../hooks/useTranslation/useTranslation';
+import { LanguageModeType, type LanguageCode } from '../types/types';
 
 export const getLanguageModeAria = (
   languageMode: LanguageModeType,

--- a/src/utils/xapi.utils.ts
+++ b/src/utils/xapi.utils.ts
@@ -1,5 +1,4 @@
-import { H5P } from 'h5p-utils';
-import {
+import type {
   IH5PContentType,
   IH5PQuestionType,
   XAPIDefinition,
@@ -7,6 +6,7 @@ import {
   XAPIInteractionType,
   XAPIVerb,
 } from 'h5p-types';
+import { H5P } from 'h5p-utils';
 
 const DEFAULT_DESCRIPTION = 'Vocabulary Drill';
 

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noImplicitAny": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "h5p-extensions.d.ts"]
 }


### PR DESCRIPTION
This forces the use of `import type` when types are imported (this is handled by auto import functionality in editors), and lets us remove the hack where semantics was used as a value.

It also decreases the module size by 5% (13 kB).