### PR TITLE
Reduce dependabot frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     package-ecosystem: npm
     rebase-strategy: auto
     schedule:
-      interval: daily
+      interval: weekly
     labels:
       - non-functional
 
@@ -12,6 +12,6 @@ updates:
     package-ecosystem: github-actions
     rebase-strategy: auto
     schedule:
-      interval: daily
+      interval: weekly
     labels:
       - non-functional


### PR DESCRIPTION
Just a suggestion. Security alerts will be issued immediately anyway, and I frankly don't see the point in being informed about newer versions of dependencies daily.