### PR TITLE
Add stylesheet overrides for Drag the Words subcontent

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -6,6 +6,50 @@
 
   .h5p-question {
     background-color: transparent;
+
+    /*
+     * Overrides that can be removed once
+     * https://h5ptechnology.atlassian.net/browse/HFP-3797 has been resolved
+     * pull request at https://github.com/h5p/h5p-drag-text/pull/143
+     */
+    &.h5p-drag-text {
+      // Override cursor state to not kick in when draggable is disabled
+      [aria-grabbed] {
+        cursor: inherit;
+
+        &:not(.ui-draggable-disabled) {
+          cursor: pointer;
+        }
+      }
+
+      /* Override hover of disabled draggables in dropzone */
+      [aria-grabbed].h5p-drag-dropped.ui-draggable-disabled:hover {
+        border: none;
+        color: #255c41;
+        background: transparent;
+      }
+
+      /* Override hover of disabled draggables in original position */
+      [aria-grabbed].ui-draggable-disabled:hover {
+        border: 0.1em solid #c6c6c6;
+        color: initial;
+        background: #ddd;
+      }
+
+      /* Override grabbed state to improve color contrast */
+      [aria-grabbed='true'] {
+        opacity: 1;
+      }
+
+      /* Override dragged state to improve color contrast */
+      [aria-grabbed='true'],
+      [aria-grabbed='true'].h5p-drag-dropped:not(.ui-draggable-disabled):hover,
+      [aria-grabbed='true']:not(.ui-draggable-disabled):hover {
+        border: 0.1em solid rgb(212,190,216);
+        color: #663366;
+        background: #edd6e9;
+      }
+    }
   }
 
   .h5p-question-introduction {


### PR DESCRIPTION
Can’t say how this ever came into being, but the CSS of draggables for Drag the Words is off and leads to issues:

- Disabling a draggable added the class ui-state-disabled, but the corresponding CSS classes to style the draggables (or rather unstyle them) were named ui-draggable-disabled (potentially some jQueryUI change). The draggables still reacted to hovering them.
- Disabling a draggable did not stop the cursor from changing.
- When selecting/dragging a draggable, the color contrast was insufficient due to opacity.

__When merged in, will override Drag the Words' stylesheet in a way that:__

- When a draggable is disabled, it does not change its style on hovering.
- When a draggable is disabled, then hovering it does not lead to the pointer to change the symbol.
- When a draggable is selected/dragged, the color contrast is sufficient.

__Will become obsolete once https://h5ptechnology.atlassian.net/browse/HFP-3797 has been dealt with.__