### PR TITLE
feat: display question content as grid

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -151,9 +151,7 @@
     &.h5p-drag-text,
     &.h5p-blanks {
       /* Make sure the grid content is reachable on mobile */
-      .h5p-question-content {
-        overflow-x: auto;
-      }
+      overflow-x: auto;
     }
   }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -123,11 +123,11 @@
         .h5p-correct-answer {
           align-self: end;
           line-height: 1.375em;
-          position: relative;
           width: fit-content;
           
           &:not(:last-child) {
             margin-bottom: 0.5rem;
+            position: relative;
 
             &::after {
               border-bottom: 1px solid #eee;
@@ -142,6 +142,17 @@
             }
           }
         }
+      }
+    }
+
+    /*
+     * Overrides to create a grid structure in H5P.DragText and H5P.Blanks
+     */
+    &.h5p-drag-text,
+    &.h5p-blanks {
+      /* Make sure the grid content is reachable on mobile */
+      .h5p-question-content {
+        overflow-x: auto;
       }
     }
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -50,6 +50,100 @@
         background: #edd6e9;
       }
     }
+
+    /*
+     * Overrides to create a grid structure in H5P.DragText
+     */
+    &.h5p-drag-text {
+      .h5p-drag-droppable-words {
+        display: grid;
+        grid-template-columns: repeat(2, max-content);
+        row-gap: 0.5rem;
+   
+        /* Add a bottom border to all children, except the last row */
+        & > *:nth-last-child(n+3) {
+          border-bottom: 1px solid #eee;
+          padding-bottom: 0.5rem;
+        }
+    
+        /* Add a right padding to the source element (left) */
+        & > span {
+          padding-right: 1rem;
+        }
+
+        /* Make sure tip follows the input */
+        .h5p-drag-dropzone-container {
+          width: fit-content;
+        }
+      }
+    }
+
+    /*
+     * Overrides to create a grid structure in H5P.Blanks
+     */
+    &.h5p-blanks {
+      .h5p-question-content p {
+        display: grid;
+        grid-template-columns: repeat(3, max-content);
+        row-gap: 0.5rem;
+     
+        /* Add a bottom border to all children, except the last row */
+        & > *:nth-last-child(n+4):not(.h5p-correct-answer),
+        & > *:nth-last-child(3).h5p-input-wrapper {
+          border-bottom: 1px solid #eee;
+          padding-bottom: 0.5rem;
+        }
+     
+        /* Place elements in the grid */
+        & > span:not(.h5p-input-wrapper, .h5p-correct-answer) {
+          grid-column-start: 1;
+          padding-right: 1rem;
+        }
+     
+        & > span.h5p-input-wrapper {
+          grid-column-start: 2;
+        }
+     
+        & > span.h5p-correct-answer {
+          grid-column-start: 3;
+        } 
+
+        /* Make all inputs the same width */
+        .h5p-text-input {
+          box-sizing: border-box;
+          width: 10rem !important;
+        }
+
+        /* Make sure inputs ::after follows input */
+        .h5p-input-wrapper {
+          width: fit-content; 
+        }
+
+        /* Create a bottom border to the correct answer */ 
+        .h5p-correct-answer {
+          align-self: end;
+          line-height: 1.375em;
+          position: relative;
+          width: fit-content;
+          
+          &:not(:last-child) {
+            margin-bottom: 0.5rem;
+
+            &::after {
+              border-bottom: 1px solid #eee;
+              content: '';
+              display: inline-block;
+              height: 100%;
+              left: -0.75rem;
+              padding: 0 0.5rem 0.5rem;
+              position: absolute;
+              top: 0;
+              width: 100%;
+            }
+          }
+        }
+      }
+    }
   }
 
   .h5p-question-introduction {

--- a/src/utils/word.utils.test.ts
+++ b/src/utils/word.utils.test.ts
@@ -192,7 +192,7 @@ describe('Vocabulary drill utils', () => {
       const words = ['ocean,sjø'];
       const showTips = true;
 
-      const expected = '<p>ocean *sjø*</p>';
+      const expected = '<p><span>ocean</span> *sjø*</p>';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -206,7 +206,7 @@ describe('Vocabulary drill utils', () => {
       const words = ['fire,ild'];
       const showTips = true;
 
-      const expected = 'fire *ild*\n';
+      const expected = 'fire *ild*';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -220,7 +220,7 @@ describe('Vocabulary drill utils', () => {
       const words = ['ocean/sea,sjø/hav'];
       const showTips = true;
 
-      const expected = '<p>ocean *sjø/hav*</p>';
+      const expected = '<p><span>ocean</span> *sjø/hav*</p>';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -234,7 +234,7 @@ describe('Vocabulary drill utils', () => {
       const words = ['fire/heat,ild/brann'];
       const showTips = true;
 
-      const expected = 'fire *ild*\n';
+      const expected = 'fire *ild*';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -248,7 +248,7 @@ describe('Vocabulary drill utils', () => {
       const words = ['ocean/sea:boats go on it,sjø/hav:båter kjører på det'];
       const showTips = true;
 
-      const expected = '<p>ocean *sjø/hav:båter kjører på det*</p>';
+      const expected = '<p><span>ocean</span> *sjø/hav:båter kjører på det*</p>';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -262,7 +262,7 @@ describe('Vocabulary drill utils', () => {
       const words = ['fire/heat:f__e,ild/brann:i_d'];
       const showTips = true;
 
-      const expected = 'fire *ild:i_d*\n';
+      const expected = 'fire *ild:i_d*';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -276,7 +276,7 @@ describe('Vocabulary drill utils', () => {
       const words = ['ocean,sjø', 'fire,ild', 'sky,himmel'];
       const showTips = true;
 
-      const expected = '<p>ocean *sjø*</p><p>fire *ild*</p><p>sky *himmel*</p>';
+      const expected = '<p><span>ocean</span> *sjø*<span>fire</span> *ild*<span>sky</span> *himmel*</p>';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -290,7 +290,7 @@ describe('Vocabulary drill utils', () => {
       const words = ['ocean,sjø', 'fire,ild', 'sky,himmel'];
       const showTips = true;
 
-      const expected = 'ocean *sjø*\nfire *ild*\nsky *himmel*\n';
+      const expected = 'ocean *sjø*fire *ild*sky *himmel*';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -306,7 +306,7 @@ describe('Vocabulary drill utils', () => {
       const showTips = true;
 
       const expected =
-        '<p>ocean *sjø/hav*</p><p>fire *ild/brann*</p><p>sky *himmel/sky*</p>';
+        '<p><span>ocean</span> *sjø/hav*<span>fire</span> *ild/brann*<span>sky</span> *himmel/sky*</p>';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -321,7 +321,7 @@ describe('Vocabulary drill utils', () => {
         ['ocean/sea,sjø/hav', 'fire/heat,ild/brann', 'sky/cloud,himmel/sky'];
       const showTips = true;
 
-      const expected = 'ocean *sjø*\nfire *ild*\nsky *himmel*\n';
+      const expected = 'ocean *sjø*fire *ild*sky *himmel*';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -337,7 +337,7 @@ describe('Vocabulary drill utils', () => {
       const showTips = true;
 
       const expected =
-        '<p>ocean *sjø/hav:båter kjører på det*</p><p>fire *ild/brann:veldig varmt*</p><p>sky *himmel/sky:over oss*</p>';
+        '<p><span>ocean</span> *sjø/hav:båter kjører på det*<span>fire</span> *ild/brann:veldig varmt*<span>sky</span> *himmel/sky:over oss*</p>';
       const actual = parseSourceAndTarget(
         words,
         showTips,
@@ -353,7 +353,7 @@ describe('Vocabulary drill utils', () => {
       const showTips = true;
 
       const expected =
-        'ocean *sjø:båter kjører på det*\nfire *ild:veldig varmt*\nsky *himmel:over oss*\n';
+        'ocean *sjø:båter kjører på det*fire *ild:veldig varmt*sky *himmel:over oss*';
       const actual = parseSourceAndTarget(
         words,
         showTips,

--- a/src/utils/word.utils.ts
+++ b/src/utils/word.utils.ts
@@ -69,9 +69,9 @@ export const pickRandomWords = (
 
 const createFillInString = (source: string, target: string, sourceLanguage?: LanguageCode): string => {
   if (!sourceLanguage) {
-    return `<p>${source} *${target}*</p>`;
+    return `<span>${source}</span> *${target}*`;
   }
-  return `<p><span lang="${sourceLanguage}">${source}</span> *${target}*</p>`;
+  return `<span lang="${sourceLanguage}">${source}</span> *${target}*`;
 };
 
 /**

--- a/src/utils/word.utils.ts
+++ b/src/utils/word.utils.ts
@@ -173,7 +173,7 @@ export const parseSourceAndTarget = (
 
   const parsedWords = newWordsList.join('');
 
-  if (answerModeFillIn) {
+  if (answerModeFillIn && parsedWords.length > 0) {
     return `<p>${parsedWords}</p>`;
   }
 

--- a/src/utils/word.utils.ts
+++ b/src/utils/word.utils.ts
@@ -66,7 +66,7 @@ export const pickRandomWords = (
  * In order to show the word on a seperate line, we wrap the string in a <p> tag.
  */
 const createFillInString = (source: string, target: string): string => {
-  return `<p>${source} *${target}*</p>`;
+  return `<span>${source}</span> *${target}*`;
 };
 
 /**
@@ -75,7 +75,7 @@ const createFillInString = (source: string, target: string): string => {
  * In order to show the word on a seperate line, we add a newline character.
  */
 const createDragTextString = (source: string, target: string): string => {
-  return `${source} *${target}*\n`;
+  return `${source} *${target}*`;
 };
 
 /**
@@ -171,6 +171,10 @@ export const parseSourceAndTarget = (
   });
 
   const parsedWords = newWordsList.join('');
+
+  if (answerModeFillIn) {
+    return `<p>${parsedWords}</p>`;
+  }
 
   return parsedWords;
 };

--- a/src/utils/word.utils.ts
+++ b/src/utils/word.utils.ts
@@ -63,7 +63,8 @@ export const pickRandomWords = (
 /**
  * Creates a word string for the H5P.Blanks content type.
  * H5P.Blanks expects the input as an HTML string on the format `source *target*`.
- * In order to show the word on a seperate line, we wrap the string in a <p> tag.
+ * A span tag is used to wrap the source word, and add styling to it.
+ * In order to show the word on a seperate line, the string can be wrapped in a <p> tag.
  */
 const createFillInString = (source: string, target: string): string => {
   return `<span>${source}</span> *${target}*`;
@@ -72,7 +73,7 @@ const createFillInString = (source: string, target: string): string => {
 /**
  * Creates a word string for the H5P.DragText content type.
  * H5P.DragText expects the input as a string on the format `source *target*`.
- * In order to show the word on a seperate line, we add a newline character.
+ * In order to show the word on a seperate line, a newline character '\n' can be added.
  */
 const createDragTextString = (source: string, target: string): string => {
   return `${source} *${target}*`;


### PR DESCRIPTION
- **Lines up the source and target words in separate columns in a grid**. The word utils `createFillInString` and `createDragTextString` have been changed to ensure that this is possible. In H5P.Blanks the source words are now placed inside their own `span` so it is easier to add css to it. 

- **Adds a line between each row in the grid** to make it easier for users to connect the source and targets words (if there is a lot of space between them). Could potentially use a color with more contrast to the background color to enhance it even more if needed.

- **Makes the input fields in H5P.Blanks the same width.** Note that this is a fixed width and that the `input` will not change width based on the input text as before. The fixed width should be tested to see if it is suitable. 

- **Adds `overflow-x: auto` to the content to ensure that it is visible and reachable on mobile** if there are some really long words. This is mostly a concern when checking answers and the grid takes up more of the width. Since the content is now displayed in a grid it will not be as responsive on its own anymore. We could also look at wrapping the content instead of enabling scroll, but it will require more time. Mobile accessibility should be tested more to ensure the best accessibility on this content type.