### PR TITLE
fix: make sure maxScore is valid

### DIFF
--- a/library.json.d.ts
+++ b/library.json.d.ts
@@ -3,7 +3,7 @@ declare const json: {
   "machineName": "H5P.VocabularyDrill",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 22,
+  "patchVersion": 24,
   "runnable": 1,
   "license": "MIT",
   "author": "NDLA",

--- a/src/components/VocabularyDrill/VocabularyDrill.tsx
+++ b/src/components/VocabularyDrill/VocabularyDrill.tsx
@@ -180,6 +180,7 @@ export const VocabularyDrill: FC<VocabularyDrillProps> = ({
   const [disableNextButton, setDisableNextButton] = useState(true);
   const [ariaLiveText, setAriaLiveText] = useState('');
   const [showResults, setShowResults] = useState(false);
+  const [isRetrying, setIsRetrying] = useState(false);
 
   const activeContentType = useRef<SubContentType | undefined>(undefined);
 
@@ -252,31 +253,29 @@ export const VocabularyDrill: FC<VocabularyDrillProps> = ({
     setDisableNextButton(false);
 
     const newScore = score + (activeContentType.current?.getScore() ?? 0);
-    const newMaxScore = maxScore + (activeContentType.current?.getMaxScore() ?? 0);
-
     setScore(newScore);
-    setMaxScore(newMaxScore);
+
+    // If retrying, the maxScore is already set
+    let newMaxScore = maxScore;
+    if (!isRetrying) {
+      newMaxScore = maxScore + (activeContentType.current?.getMaxScore() ?? 0);
+      setMaxScore(newMaxScore);
+    }
+
+    setIsRetrying(false);
 
     // If all answers are correct, show the score page
-    const validMaxScore = newMaxScore !== 0;
-    if (!multiplePages && (newScore === newMaxScore) && validMaxScore) {
+    if (!multiplePages && (newScore === newMaxScore)) {
       handleShowResults();
     }
   };
 
   const handleRetry = (): void => {
+    setIsRetrying(true);
     setDisableTools(false);
     setDisableNextButton(true);
 
-    if (page > 0) {
-      setScore(score - (activeContentType.current?.getScore() ?? 0));
-      setMaxScore(maxScore - (activeContentType.current?.getMaxScore() ?? 0));
-    }
-    else {
-      // Reset the score
-      setScore(0);
-      setMaxScore(0);
-    }
+    setScore(score - (activeContentType.current?.getScore() ?? 0));
   };
 
   const handleShowSolution = (): void => {

--- a/src/components/VocabularyDrill/VocabularyDrill.tsx
+++ b/src/components/VocabularyDrill/VocabularyDrill.tsx
@@ -258,7 +258,8 @@ export const VocabularyDrill: FC<VocabularyDrillProps> = ({
     setMaxScore(newMaxScore);
 
     // If all answers are correct, show the score page
-    if (!multiplePages && (newScore === newMaxScore)) {
+    const validMaxScore = newMaxScore !== 0;
+    if (!multiplePages && (newScore === newMaxScore) && validMaxScore) {
       handleShowResults();
     }
   };
@@ -267,8 +268,15 @@ export const VocabularyDrill: FC<VocabularyDrillProps> = ({
     setDisableTools(false);
     setDisableNextButton(true);
 
-    setScore(score - (activeContentType.current?.getScore() ?? 0));
-    setMaxScore(maxScore - (activeContentType.current?.getMaxScore() ?? 0));
+    if (page > 0) {
+      setScore(score - (activeContentType.current?.getScore() ?? 0));
+      setMaxScore(maxScore - (activeContentType.current?.getMaxScore() ?? 0));
+    }
+    else {
+      // Reset the score
+      setScore(0);
+      setMaxScore(0);
+    }
   };
 
   const handleShowSolution = (): void => {


### PR DESCRIPTION
maxScore is often wrong after retry, especially when combining it with changing between the answer modes. The maxScore can end up being a negative number or 0. The solution I found was to avoid subtracting the maxScore in handleRetry.

Test case where the issue was noticeable (I had 4 words separated on 2 pages):
1. Start Vocabulary drill with "Fill in" selected as answer mode.
2. Answer all words correct on first page.
3. Go to next page.
4. Answer incorrect on one or more words on the next page.
9. Choose retry.
10. Change answer mode to "Drag text".
11. Answer all words correct.
12. Finish.
13. Score is 2/2, and should be 4/4. 