### PR TITLE
Fix word parsing for empty hints

### DIFF
--- a/src/utils/word.utils.test.ts
+++ b/src/utils/word.utils.test.ts
@@ -4,6 +4,7 @@ import {
   filterWord,
   parseSourceAndTarget,
   pickWords,
+  parseWords,
 } from './word.utils';
 
 describe('Vocabulary drill utils', () => {
@@ -394,6 +395,17 @@ describe('Vocabulary drill utils', () => {
 
       const expected: Array<string> = [];
       const actual = pickWords(words, page, pageSize);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe(parseWords.name, () => {
+    it('should remove empty hints from words', () => {
+      const words = 'ocean/sea:,sjø/hav:båter kjører på det\nfire/heat:very varm,ild/brann:';
+
+      const expected = ['ocean/sea,sjø/hav:båter kjører på det', 'fire/heat:very varm,ild/brann'];
+      const actual = parseWords(words, false);
 
       expect(actual).toEqual(expected);
     });

--- a/src/utils/word.utils.ts
+++ b/src/utils/word.utils.ts
@@ -201,7 +201,10 @@ export const parseWords = (
     return [];
   }
 
-  let wordsList = words.split(wordsSeparator).filter((word) => !!word.trim());
+  let wordsList = words.split(wordsSeparator)
+    .filter((word) => !!word.trim())
+    // Remove empty hints
+    .map((word) => word.replace(/:,/g, ',').replace(/:$/g, ''));
 
   if (randomize) {
     wordsList = getRandomWords(wordsList);


### PR DESCRIPTION
When merged in, will not remove an entry that contains an empty hint.